### PR TITLE
Oops forgot one $ROOT

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -112,7 +112,7 @@ post_patch() {
 
   cp $KERNEL_CFG_FILE $PKG_BUILD/.config
   if [ ! "$BUILD_ANDROID_BOOTIMG" = "yes" ]; then
-    sed -i -e "s|^CONFIG_INITRAMFS_SOURCE=.*$|CONFIG_INITRAMFS_SOURCE=\"$ROOT/$BUILD/image/initramfs.cpio\"|" $PKG_BUILD/.config
+    sed -i -e "s|^CONFIG_INITRAMFS_SOURCE=.*$|CONFIG_INITRAMFS_SOURCE=\"/$BUILD/image/initramfs.cpio\"|" $PKG_BUILD/.config
   fi
 
   # set default hostname based on $DISTRONAME


### PR DESCRIPTION
With $ROOT the package does not compile (on Ubuntu) because it adds the root of the mount and $TOOLCHAIN already has it.

```
/bin/sh: 1: /home/EmuELEC-H3//home/EmuELEC-H3/build.EmuELEC-H3.arm-3.1/toolchain/bin/host-gcc: not found
make[2]: *** [scripts/Makefile.host:118: scripts/basic/fixdep] Error 127
```