### PR TITLE
Fix ES audio, and set audio device 1,0 as default

### DIFF
--- a/packages/sx05re/emuelec/config/asound.conf
+++ b/packages/sx05re/emuelec/config/asound.conf
@@ -1,6 +1,6 @@
 pcm.!default {
 type plug
 slave {
-pcm "hw:0,1"
+pcm "hw:1,0"
 }
 }

--- a/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
+++ b/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
@@ -23,7 +23,7 @@ ee_splash.enabled=1
 ## Some external HDDs take longer to mount than ES to load, if your external ROMS do not mount in time, increase this timer
 #ee_load.delay=0
 
-# Audio device to use, comment for auto, other options 0,0 (default) 0,1 (for some AV outputs)
+# Audio device to use, comment for auto, other options 0,0 (usually default, but not on H3), 0,1 (for some AV outputs), 1,0 (default), 1,1
 #ee_audio_device=auto
 
 ## EmulationStation menu style

--- a/packages/sx05re/emuelec/config/emuelec/scripts/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/config/emuelec/scripts/emuelecRunEmu.sh
@@ -12,7 +12,7 @@ arguments="$@"
 
 #set audio device out according to emuelec.conf
 AUDIO_DEVICE="hw:$(get_ee_setting ee_audio_device)"
-[ $AUDIO_DEVICE = "hw:" ] &&  AUDIO_DEVICE="hw:0,0"
+[ $AUDIO_DEVICE = "hw:" ] &&  AUDIO_DEVICE="hw:1,0"
 sed -i "s|pcm \"hw:.*|pcm \"${AUDIO_DEVICE}\"|" /storage/.config/asound.conf
 
 # set audio to alsa

--- a/packages/sx05re/emuelec/config/emuelec/scripts/rr_audio.sh
+++ b/packages/sx05re/emuelec/config/emuelec/scripts/rr_audio.sh
@@ -9,7 +9,7 @@ export PULSE_RUNTIME_PATH=/run/pulse
 	RR_AUDIO_DEVICE="hw:$(get_ee_setting ee_audio_device)"
 	[ $RR_AUDIO_DEVICE = "hw:" ] && RR_PA_UDEV="true" || RR_PA_UDEV="false"
 	echo "Set-Audio: Using audio device $RR_AUDIO_DEVICE"
-    RR_PA_TSCHED="true"
+    RR_PA_TSCHED="false"
     RR_AUDIO_VOLUME="100"
     RR_AUDIO_BACKEND="PulseAudio"
 	


### PR DESCRIPTION
On Orange PI PC default HDMI audio is HW:1,0
Change TSCHED to "false" to fix audio (BGM and video snaps) on ES and also fix a random freeze when launching games. 